### PR TITLE
fix: resolve release workflow issues and add JSR publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,31 @@ jobs:
       - name: Run TypeScript type checking
         run: bun run type-check
 
+  jsr-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Validate JSR TypeScript requirements
+        shell: bash
+        run: |
+          echo "🔍 Validating JSR TypeScript compatibility..."
+          
+          # JSR requires explicit return types for all public API functions
+          # This prevents the "slow types" error during JSR publishing
+          npx jsr publish --dry-run --allow-dirty
+          
+          echo "✅ JSR TypeScript validation passed"
+
   security-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -100,6 +100,13 @@ jobs:
           bun run lint
           echo "✅ Linter passed"
 
+      - name: Validate JSR compatibility
+        shell: bash
+        run: |
+          echo "🔍 Validating JSR TypeScript compatibility..."
+          bun run jsr-check
+          echo "✅ JSR validation passed"
+
   release:
     needs: pre-release-checks
     runs-on: ubuntu-latest

--- a/docs/releases/UNRELEASED.md
+++ b/docs/releases/UNRELEASED.md
@@ -23,10 +23,18 @@
 - Improve release workflow to detect and warn when UNRELEASED.md contains only template content
 - Add JSR publishing to manual release workflow with OIDC authentication
 - Update deno.json version to match current package.json version (0.2.7)
+- Improve release workflow to detect and warn when UNRELEASED.md contains only template content
+- Add JSR publishing to manual release workflow with OIDC authentication
+- Update deno.json version to match current package.json version (0.2.7)
+- Add explicit return type to enhancedTranslator.refineDescription for JSR compatibility
 
 ## 🏗️ Development
 
 - Improve UNRELEASED.md template with clearer instructions and examples
+- Improve UNRELEASED.md template with clearer instructions and examples
+- Add JSR TypeScript validation to CI pipeline to catch publishing issues early
+- Add JSR compatibility check to manual release workflow pre-checks
+- Add local JSR validation script: `bun run jsr-check`
 
 ## 📚 Documentation
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:coverage": "bun test --coverage",
     "type-check": "tsc --noEmit",
     "security-check": "grep -r -E '(sk-[a-zA-Z0-9]{32,}|api[_-]?key[[:space:]]*[:=][[:space:]]*[a-zA-Z0-9_-]{20,}|npm_[a-zA-Z0-9]{36})' --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git --exclude='*.md' --exclude='.env*' --include='*.ts' --include='*.js' --include='*.json' . 2>/dev/null || echo '✅ No API keys detected in code files'",
+    "jsr-check": "npx jsr publish --dry-run --allow-dirty",
     "release:prepare": "scripts/release-helper.sh prepare",
     "release:finalize": "scripts/release-helper.sh finalize",
     "release:add-change": "scripts/release-helper.sh add-change",

--- a/src/services/enhancedTranslator.ts
+++ b/src/services/enhancedTranslator.ts
@@ -82,7 +82,7 @@ The translations should feel natural and appropriate for this specific project t
   /**
    * Refine a raw project description for translation context.
    */
-  async refineDescription(rawDescription: string) {
+  async refineDescription(rawDescription: string): Promise<string> {
     return await this.contextExtractor.refineProjectDescription(rawDescription);
   }
 


### PR DESCRIPTION
- Fix manual release workflow missing JSR publishing step
- Create proper release notes for v0.2.7 retroactively
- Improve release workflow to detect empty UNRELEASED.md template
- Update deno.json version to match package.json (0.2.7)
- Add OIDC authentication for JSR publishing
- Improve UNRELEASED.md template with clearer instructions

Resolves missing JSR publishing in manual releases and fixes changelog tracking system for future releases.