### PR TITLE
fix: resolve release workflow issues and add JSR publishing

### DIFF
--- a/docs/releases/UNRELEASED.md
+++ b/docs/releases/UNRELEASED.md
@@ -17,16 +17,21 @@
 - Fix release workflow using template UNRELEASED.md instead of actual changes
 - Create proper release notes for v0.2.7 retroactively
 - Fix manual release workflow missing JSR publishing step
+- Fix missing jsr-check script in package.json causing CI failure
 
 ## 🔧 Improvements
 
 - Improve release workflow to detect and warn when UNRELEASED.md contains only template content
 - Add JSR publishing to manual release workflow with OIDC authentication
 - Update deno.json version to match current package.json version (0.2.7)
+- Add explicit return type to enhancedTranslator.refineDescription for JSR compatibility
 
 ## 🏗️ Development
 
 - Improve UNRELEASED.md template with clearer instructions and examples
+- Add JSR TypeScript validation to CI pipeline to catch publishing issues early
+- Add JSR compatibility check to manual release workflow pre-checks
+- Add local JSR validation script: `bun run jsr-check`
 
 ## 📚 Documentation
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:coverage": "bun test --coverage",
     "type-check": "tsc --noEmit",
     "security-check": "grep -r -E '(sk-[a-zA-Z0-9]{32,}|api[_-]?key[[:space:]]*[:=][[:space:]]*[a-zA-Z0-9_-]{20,}|npm_[a-zA-Z0-9]{36})' --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git --exclude='*.md' --exclude='.env*' --include='*.ts' --include='*.js' --include='*.json' . 2>/dev/null || echo '✅ No API keys detected in code files'",
+    "jsr-check": "npx jsr publish --dry-run --allow-dirty",
     "release:prepare": "scripts/release-helper.sh prepare",
     "release:finalize": "scripts/release-helper.sh finalize",
     "release:add-change": "scripts/release-helper.sh add-change",

--- a/src/services/enhancedTranslator.ts
+++ b/src/services/enhancedTranslator.ts
@@ -82,7 +82,7 @@ The translations should feel natural and appropriate for this specific project t
   /**
    * Refine a raw project description for translation context.
    */
-  async refineDescription(rawDescription: string) {
+  async refineDescription(rawDescription: string): Promise<string> {
     return await this.contextExtractor.refineProjectDescription(rawDescription);
   }
 


### PR DESCRIPTION
- Fix manual release workflow missing JSR publishing step
- Fix release workflow using template UNRELEASED.md instead of actual changes
- Create proper release notes for v0.2.7 retroactively
- Add JSR TypeScript validation to prevent publishing failures
- Fix missing explicit return type in enhancedTranslator.refineDescription
- Add JSR compatibility checks to CI pipeline and local development
- Update deno.json version to match package.json (0.2.7)
- Add comprehensive changelog tracking system with mandatory updates

Key improvements:
- JSR publishing now included in manual releases with OIDC auth
- Early detection of JSR TypeScript issues in CI
- No more NPM/JSR version inconsistencies
- Clear warnings when UNRELEASED.md has no real changes
- Local JSR validation with 'bun run jsr-check'

Fixes #1 #2 #3 - Release workflow completeness